### PR TITLE
Add relative path-based module loading for require

### DIFF
--- a/webui-src/.eslintrc.json
+++ b/webui-src/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true
+    },
+    "extends": "eslint:recommended",
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parserOptions": {
+        "ecmaVersion": 2018
+    },
+    "rules": {
+        "indent": [
+            "error",
+            4
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+}

--- a/webui-src/app/config/config_network.js
+++ b/webui-src/app/config/config_network.js
@@ -1,7 +1,7 @@
 let m = require('mithril');
 let rs = require('rswebui');
 
-let util = require('config_util');
+let util = require('config/config_util');
 
 
 let SetNwMode = () => {

--- a/webui-src/app/config/config_resolver.js
+++ b/webui-src/app/config/config_resolver.js
@@ -4,11 +4,11 @@ let widget = require('widgets');
 
 
 let sections = {
-  network: require('config_network'),
-  node: require('config_node'),
-  services: require('config_services'),
-  files: require('config_files'),
-  people: require('config_people'),
+  network: require('config/config_network'),
+  node: require('config/config_node'),
+  services: require('config/config_services'),
+  files: require('config/config_files'),
+  people: require('config/config_people'),
 };
 
 const Layout = {

--- a/webui-src/app/files/files_downloads.js
+++ b/webui-src/app/files/files_downloads.js
@@ -1,6 +1,6 @@
 let m = require('mithril');
 let rs = require('rswebui');
-let util = require('files_util')
+let util = require('files/files_util')
 let widget = require('widgets');
 
 

--- a/webui-src/app/files/files_resolver.js
+++ b/webui-src/app/files/files_resolver.js
@@ -2,10 +2,10 @@ let m = require('mithril');
 let rs = require('rswebui');
 let widget = require('widgets');
 
-let downloads = require('files_downloads');
-let uploads = require('files_uploads');
-let util = require('files_util');
-let search = require('files_search');
+let downloads = require('files/files_downloads');
+let uploads = require('files/files_uploads');
+let util = require('files/files_util');
+let search = require('files/files_search');
 
 
 const MyFiles = () => {

--- a/webui-src/app/files/files_search.js
+++ b/webui-src/app/files/files_search.js
@@ -1,6 +1,6 @@
 let m = require('mithril');
 let rs = require('rswebui');
-let util = require('files_util')
+let util = require('files/files_util')
 
 
 let matchString = '';

--- a/webui-src/app/files/files_uploads.js
+++ b/webui-src/app/files/files_uploads.js
@@ -1,6 +1,6 @@
 let m = require('mithril');
 let rs = require('rswebui');
-let util = require('files_util')
+let util = require('files/files_util')
 
 
 function updateFileDetail(hash, isNew = false) {

--- a/webui-src/app/mail/mail_draftbox.js
+++ b/webui-src/app/mail/mail_draftbox.js
@@ -1,6 +1,6 @@
 const m = require('mithril');
 const rs = require('rswebui');
-const util = require('mail_util');
+const util = require('mail/mail_util');
 
 
 const Layout = () => {

--- a/webui-src/app/mail/mail_inbox.js
+++ b/webui-src/app/mail/mail_inbox.js
@@ -1,6 +1,6 @@
 const m = require('mithril');
 const rs = require('rswebui');
-const util = require('mail_util');
+const util = require('mail/mail_util');
 
 
 const Layout = () => {

--- a/webui-src/app/mail/mail_outbox.js
+++ b/webui-src/app/mail/mail_outbox.js
@@ -1,6 +1,6 @@
 const m = require('mithril');
 const rs = require('rswebui');
-const util = require('mail_util');
+const util = require('mail/mail_util');
 
 
 const Layout = () => {

--- a/webui-src/app/mail/mail_resolver.js
+++ b/webui-src/app/mail/mail_resolver.js
@@ -1,6 +1,6 @@
 let m = require('mithril');
 let rs = require('rswebui');
-let util = require('mail_util');
+let util = require('mail/mail_util');
 let widget = require('widgets');
 
 
@@ -27,10 +27,10 @@ const Messages = {
 }
 
 let sections = {
-  inbox: require('mail_inbox'),
-  outbox: require('mail_outbox'),
-  drafts: require('mail_draftbox'),
-  sent: require('mail_sentbox'),
+  inbox: require('mail/mail_inbox'),
+  outbox: require('mail/mail_outbox'),
+  drafts: require('mail/mail_draftbox'),
+  sent: require('mail/mail_sentbox'),
 };
 
 const Layout = {

--- a/webui-src/app/mail/mail_sentbox.js
+++ b/webui-src/app/mail/mail_sentbox.js
@@ -1,6 +1,6 @@
 const m = require('mithril');
 const rs = require('rswebui');
-const util = require('mail_util');
+const util = require('mail/mail_util');
 
 
 const Layout = () => {

--- a/webui-src/app/mail/mail_util.js
+++ b/webui-src/app/mail/mail_util.js
@@ -1,6 +1,6 @@
 const m = require('mithril');
 const rs = require('rswebui');
-const people = require('people_util');
+const people = require('people/people_util');
 
 const RS_MSG_BOXMASK = 0x000f;
 

--- a/webui-src/app/main.js
+++ b/webui-src/app/main.js
@@ -53,13 +53,13 @@ const Layout = () => {
 
 function onSuccess() {
   let home = require('home');
-  let network = require('network');
-  let people = require('people');
-  let chat = require('chat');
-  let mail = require('mail_resolver');
-  let files = require('files_resolver');
-  let channels = require('channels');
-  let config = require('config_resolver');
+  let network = require('network/network');
+  let people = require('people/people');
+  let chat = require('chat/chat');
+  let mail = require('mail/mail_resolver');
+  let files = require('files/files_resolver');
+  let channels = require('channels/channels');
+  let config = require('config/config_resolver');
 
   m.route(document.getElementById('main'), '/home', {
     '/home': {

--- a/webui-src/app/network/network.js
+++ b/webui-src/app/network/network.js
@@ -1,7 +1,7 @@
 const m = require('mithril');
 const rs = require('rswebui');
 const widget = require('widgets');
-const Data = require('network_data');
+const Data = require('network/network_data');
 
 const ConfirmRemove = () => {
   return {

--- a/webui-src/app/people/people.js
+++ b/webui-src/app/people/people.js
@@ -1,7 +1,7 @@
 let m = require('mithril');
 let rs = require('rswebui');
 
-let OwnIds = require('people_ownids');
+let OwnIds = require('people/people_ownids');
 
 const Contacts = {
   list: [],

--- a/webui-src/make-src/build.sh
+++ b/webui-src/make-src/build.sh
@@ -31,8 +31,9 @@ if [ "$2" = "" ]||[ "$2" = "app.js" ]; then
 	echo - copy template.js ...
 	cp $src/make-src/template.js $publicdest/app.js
 
+        js_source=$src/app/
 	for filename in $src/app/**/*.js; do
-		fname=$(basename "$filename")
+                fname="${filename#$js_source}"
 		fname="${fname%.*}"
 		echo - adding $fname ...
 		echo require.register\(\"$fname\", function\(exports, require, module\) { >> $publicdest/app.js

--- a/webui-src/make-src/template.js
+++ b/webui-src/make-src/template.js
@@ -1,112 +1,114 @@
 (function() {
-  'use strict';
+    'use strict';
 
-  var globals = typeof window === 'undefined' ? global : window;
-  if (typeof globals.require === 'function') return;
+    const globals = typeof window === 'undefined' ? global : window;
+    if (typeof globals.require === 'function') return;
 
-  var modules = {};
-  var cache = {};
-  var aliases = {};
-  var has = ({}).hasOwnProperty;
+    let modules = {},
+        cache = {},
+        aliases = {},
+        has = {}.hasOwnProperty;
 
-  var endsWith = function(str, suffix) {
-    return str.indexOf(suffix, str.length - suffix.length) !== -1;
-  };
-
-  var _cmp = 'components/';
-  var unalias = function(alias, loaderPath) {
-    var start = 0;
-    if (loaderPath) {
-      if (loaderPath.indexOf(_cmp) === 0) {
-        start = _cmp.length;
-      }
-      if (loaderPath.indexOf('/', start) > 0) {
-        loaderPath = loaderPath.substring(start, loaderPath.indexOf('/', start));
-      }
-    }
-    var result = aliases[alias + '/index.js'] || aliases[loaderPath + '/deps/' + alias + '/index.js'];
-    if (result) {
-      return _cmp + result.substring(0, result.length - '.js'.length);
-    }
-    return alias;
-  };
-
-  var _reg = /^\.\.?(\/|$)/;
-  var expand = function(root, name) {
-    var results = [], part;
-    var parts = (_reg.test(name) ? root + '/' + name : name).split('/');
-    for (var i = 0, length = parts.length; i < length; i++) {
-      part = parts[i];
-      if (part === '..') {
-        results.pop();
-      } else if (part !== '.' && part !== '') {
-        results.push(part);
-      }
-    }
-    return results.join('/');
-  };
-
-  var dirname = function(path) {
-    return path.split('/').slice(0, -1).join('/');
-  };
-
-  var localRequire = function(path) {
-    return function expanded(name) {
-      var absolute = expand(dirname(path), name);
-      return globals.require(absolute, path);
-    };
-  };
-
-  var initModule = function(name, definition) {
-    var module = {id: name, exports: {}};
-    cache[name] = module;
-    definition(module.exports, localRequire(name), module);
-    return module.exports;
-  };
-
-  var require = function(name, loaderPath) {
-    var path = expand(name, '.');
-    if (loaderPath == null) loaderPath = '/';
-    path = unalias(name, loaderPath);
-
-    if (has.call(cache, path)) return cache[path].exports;
-    if (has.call(modules, path)) return initModule(path, modules[path]);
-
-    var dirIndex = expand(path, './index');
-    if (has.call(cache, dirIndex)) return cache[dirIndex].exports;
-    if (has.call(modules, dirIndex)) return initModule(dirIndex, modules[dirIndex]);
-
-    throw new Error('Cannot find module "' + name + '" from '+ '"' + loaderPath + '"');
-  };
-
-  require.alias = function(from, to) {
-    aliases[to] = from;
-  };
-
-  require.register = require.define = function(bundle, fn) {
-    if (typeof bundle === 'object') {
-      for (var key in bundle) {
-        if (has.call(bundle, key)) {
-          modules[key] = bundle[key];
+    const unalias = function(alias, loaderPath) {
+        const _cmp = 'components/';
+        let start = 0;
+        if (loaderPath) {
+            if (loaderPath.startsWith(_cmp)) {
+                start = _cmp.length;
+            }
+            if (loaderPath.indexOf('/', start) > 0) {
+                loaderPath = loaderPath.substring(
+                    start,
+                    loaderPath.indexOf('/', start)
+                );
+            }
         }
-      }
-    } else {
-      modules[bundle] = fn;
-    }
-  };
+        const result =
+      aliases[alias + '/index.js'] ||
+      aliases[loaderPath + '/deps/' + alias + '/index.js'];
+        if (result) {
+            return _cmp + result.substring(0, result.length - '.js'.length);
+        }
+        return alias;
+    };
 
-  require.list = function() {
-    var result = [];
-    for (var item in modules) {
-      if (has.call(modules, item)) {
-        result.push(item);
-      }
-    }
-    return result;
-  };
+    const expand = function(root, name) {
+        const _reg = /^\.\.?(\/|$)/;
+        let results = [],
+            parts = (_reg.test(name) ? root + '/' + name : name).split('/');
+        for (let part of parts) {
+            if (part === '..') {
+                results.pop();
+            } else if (part !== '.' && part !== '') {
+                results.push(part);
+            }
+        }
+        return results.join('/');
+    };
 
-  require.brunch = true;
-  require._cache = cache;
-  globals.require = require;
+    const dirname = function(path) {
+        return path
+            .split('/')
+            .slice(0, -1)
+            .join('/');
+    };
+
+    const localRequire = function(path) {
+        return function(name) {
+            let absolute = expand(dirname(path), name);
+            return globals.require(absolute, path);
+        };
+    };
+
+    const initModule = function(name, definition) {
+        let module = { id: name, exports: {} };
+        cache[name] = module;
+        definition(module.exports, localRequire(name), module);
+        return module.exports;
+    };
+
+    const require = function(name, loaderPath) {
+        if (loaderPath === undefined) loaderPath = '/';
+        let path = unalias(name, loaderPath);
+
+        if (path in cache) return cache[path].exports;
+        if (path in modules) return initModule(path, modules[path]);
+
+        let dirIndex = expand(path, './index');
+        if (dirIndex in cache) return cache[dirIndex].exports;
+        if (dirIndex in modules) return initModule(dirIndex, modules[dirIndex]);
+
+        throw new Error(
+            'Cannot find module "' + name + '" from ' + '"' + loaderPath + '"'
+        );
+    };
+
+    require.alias = function(from, to) {
+        aliases[to] = from;
+    };
+
+    require.register = require.define = function(bundle, fn) {
+        if (typeof bundle === 'object') {
+            for (let key in bundle) {
+                if (has.call(bundle, key)) {
+                    modules[key] = bundle[key];
+                }
+            }
+        } else {
+            modules[bundle] = fn;
+        }
+    };
+
+    require.list = function() {
+        let result = [];
+        for (let item in modules) {
+            if (has.call(modules, item)) {
+                result.push(item);
+            }
+        }
+        return result;
+    };
+
+    require._cache = cache;
+    globals.require = require;
 })();
-


### PR DESCRIPTION
Improve the `require()` polyfill function from the `template.js` file to add ability to load modules by using relative path names.
The `build.sh` script is able to pass the relative full pathname of all js files.

The modules can be loaded properly using their paths, Instead of using only names.

This also removes the requirement of maintaining a unique filename and module name for every single module in `src/`.

Before:
```javascript
require('some_module_name')
```
Now:
```javascript
require('path/to/module')
```