### PR TITLE
Explicitly convert data rate values to number before API call

### DIFF
--- a/webui-src/app/config/config_network.js
+++ b/webui-src/app/config/config_network.js
@@ -50,7 +50,7 @@ let SetLimits = () => {
       m(
         'input[type=number][name=download]', {
           value: dlim,
-          oninput: (e) => dlim = e.target.value,
+          oninput: (e) => dlim = Number(e.target.value),
           onchange: setMaxRates,
         }),
       m('p',
@@ -62,7 +62,7 @@ let SetLimits = () => {
         ), 'Upload limit(KB/s):'),
       m('input[type=number][name=upload]', {
         value: ulim,
-        oninput: (e) => ulim = e.target.value,
+        oninput: (e) => ulim = Number(e.target.value),
         onchange: setMaxRates,
       }),
     ],


### PR DESCRIPTION
The `onInput` attr does not return the number input element's value as a number. This will explicitly convert the value to a number before making the API call.

Fixes #10 