### PR TITLE
Serialize new file request's payload manually

### DIFF
--- a/webui-src/app/files/files_downloads.js
+++ b/webui-src/app/files/files_downloads.js
@@ -84,7 +84,14 @@ function addFile(url) {
   }
   rs.rsJsonApiRequest(
     '/rsFiles/FileRequest',
-    {},
+    {
+      fileName: details.name,
+      hash: details.hash,
+      flags: util.RS_FILE_REQ_ANONYMOUS_ROUTING,
+      size: {
+        xstr64: details.size,
+      },
+    },
     (status) => {
       widget.popupMessage([
         m('i.fas.fa-file-medical'),
@@ -92,18 +99,7 @@ function addFile(url) {
         m('hr'),
         m('p', 'Successfully added file!'),
       ]);
-    },
-    true,
-    {},
-    undefined,
-    // NOTE: Payload is passed through serializer since JS cannot
-    // represent filesizes >2Gi using `Number` accurately
-    () => `{
-        "fileName": "${details.name}",
-        "hash": "${details.hash}",
-        "flags": ${util.RS_FILE_REQ_ANONYMOUS_ROUTING},
-        "size": ${details.size}
-        }`
+    }
   );
 }
 

--- a/webui-src/app/files/files_downloads.js
+++ b/webui-src/app/files/files_downloads.js
@@ -84,13 +84,7 @@ function addFile(url) {
   }
   rs.rsJsonApiRequest(
     '/rsFiles/FileRequest',
-    {
-      fileName: details.name,
-      hash: details.hash,
-
-      flags: util.RS_FILE_REQ_ANONYMOUS_ROUTING,
-      size: details.size,
-    },
+    {},
     (status) => {
       widget.popupMessage([
         m('i.fas.fa-file-medical'),
@@ -98,7 +92,18 @@ function addFile(url) {
         m('hr'),
         m('p', 'Successfully added file!'),
       ]);
-    }
+    },
+    true,
+    {},
+    undefined,
+    // NOTE: Payload is passed through serializer since JS cannot
+    // represent filesizes >2Gi using `Number` accurately
+    () => `{
+        "fileName": "${details.name}",
+        "hash": "${details.hash}",
+        "flags": ${util.RS_FILE_REQ_ANONYMOUS_ROUTING},
+        "size": ${details.size}
+        }`
   );
 }
 


### PR DESCRIPTION
Fixes #47
The `rsFiles/FileRequest` API expects an integer in the `size` property and does not work with a string value.
JS `Number` cannot hold size values for files > 2Gb.
The only way to pass size without truncating the number seems to be by manually serializing the payload data.