### PR TITLE
Update home.js

### DIFF
--- a/webui-src/app/home.js
+++ b/webui-src/app/home.js
@@ -145,6 +145,7 @@ function confirmAddPrompt(details, cert, long) {
               const res = await rs.rsJsonApiRequest('/rsPeers/addSslOnlyFriend', {
                 sslId: details.id,
                 pgpId: details.gpg_id,
+                details
               });
               if (res.body.retval) {
                 widget.popupMessage([


### PR DESCRIPTION
When adding a friend through webui the destination address is not added, adding 'details' to the addSslOnlyFriend fixes this issue.

Note
This is tested with .b32.i2p addresses, but it should work on normal IP as well as .onion addresses.