### PR TITLE
Decode HTML entities in chat messages

### DIFF
--- a/webui-src/app/chat/chat_state.js
+++ b/webui-src/app/chat/chat_state.js
@@ -89,6 +89,27 @@ function getStatusTooltip(status) {
   }
 }
 
+// Chat messages travel as HTML. Stripping the tags is not enough: the entities
+// they leave behind are still raw text and end up displayed verbatim, the most
+// visible one being the &nbsp; that Qt emits for leading and repeated spaces.
+// A textarea decodes them without ever parsing markup, since its content model
+// is plain text and nothing in the string can become an element.
+function decodeHtmlEntities(text) {
+  const el = document.createElement('textarea');
+  el.innerHTML = text;
+  return el.value;
+}
+
+// Turn the HTML payload of a chat message into the text we display.
+function htmlToText(text) {
+  return decodeHtmlEntities(
+    text
+      .replaceAll('<br/>', '\n')
+      .replaceAll('<br>', '\n')
+      .replace(new RegExp('<style[^<]*</style>|<[^>]*>', 'gm'), '')
+  );
+}
+
 function renderChatMessage(rawText) {
   if (!rawText) return '';
 
@@ -103,10 +124,7 @@ function renderChatMessage(rawText) {
     while ((match = imgRegex.exec(rawText)) !== null) {
       if (match.index > lastIndex) {
         const precedingText = rawText.substring(lastIndex, match.index);
-        const cleanText = precedingText
-          .replaceAll('<br/>', '\n')
-          .replaceAll('<br>', '\n')
-          .replace(new RegExp('<style[^<]*</style>|<[^>]*>', 'gm'), '');
+        const cleanText = htmlToText(precedingText);
         if (cleanText) {
           parts.push(renderTextWithEmoji(cleanText));
         }
@@ -142,10 +160,7 @@ function renderChatMessage(rawText) {
 
     if (lastIndex < rawText.length) {
       const trailingText = rawText.substring(lastIndex);
-      const cleanText = trailingText
-        .replaceAll('<br/>', '\n')
-        .replaceAll('<br>', '\n')
-        .replace(new RegExp('<style[^<]*</style>|<[^>]*>', 'gm'), '');
+      const cleanText = htmlToText(trailingText);
       if (cleanText) {
         parts.push(renderFormattedMessageText(cleanText));
       }
@@ -179,12 +194,11 @@ function renderChatMessage(rawText) {
   }
 
   // 3. Normal text message
-  const cleanText = rawText
-    .replace(/<blockquote[^>]*>/gi, '\n> ')
-    .replace(/<\/blockquote>/gi, '\n')
-    .replaceAll('<br/>', '\n')
-    .replaceAll('<br>', '\n')
-    .replace(new RegExp('<style[^<]*</style>|<[^>]*>', 'gm'), '');
+  const cleanText = htmlToText(
+    rawText
+      .replace(/<blockquote[^>]*>/gi, '\n> ')
+      .replace(/<\/blockquote>/gi, '\n')
+  );
 
   return renderFormattedMessageText(cleanText);
 }

--- a/webui-src/app/main.js
+++ b/webui-src/app/main.js
@@ -114,7 +114,7 @@ const navbar = () => {
                       ? 'Connected to RetroShare Core'
                       : 'Connection Lost',
                   }),
-                  m('span.webui-version', { style: { fontSize: '0.7em' } }, 'v131'),
+                  m('span.webui-version', { style: { fontSize: '0.7em' } }, 'v132'),
                   m('i.fas.fa-sync-alt.refresh-icon', {
                     style: { cursor: 'pointer', fontSize: '0.8em' },
                     onclick: () => window.location.reload(true),


### PR DESCRIPTION
Chat messages are carried as HTML. `renderChatMessage()` strips the tags but never decodes the entities left behind, and the result goes into a mithril text node, so they are displayed verbatim.

The visible case is a plain space: RetroShare sends the message as HTML as soon as the composer holds any formatting, and `QTextDocument::toHtml()` turns leading and repeated spaces into `&nbsp;`, which the web UI then shows as that literal string. `&amp;`, `&lt;` and `&gt;` were affected the same way.

The three call sites that turned HTML into text carried the same replacements, so they now share `htmlToText()`. Decoding goes through a textarea rather than a div on purpose: the content model of a textarea is plain text, so no part of a message can be parsed into an element. Nothing is trusted as markup.

Tested on Linux against a Qt GUI peer: sending a message with spaces no longer shows `&nbsp;` in the web UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
